### PR TITLE
ci: fix oidc token caching issue in CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,10 +38,6 @@ jobs:
 
       - name: test
         run: make test INSTALL_EXTRA=test
-        env:
-          # Use the pubic OIDC beacon for online tests, rather than relying
-          # on the workflow's own ID token.
-          EXTREMELY_DANGEROUS_PUBLIC_OIDC_BEACON: 1
 
   test-offline:
     runs-on: ubuntu-latest

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,25 +1,89 @@
+import functools
+import json
 import os
+import subprocess
+import time
+from base64 import b64decode
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
 
 import pytest
 from sigstore import oidc
 
 
-@pytest.fixture(scope="session")
-def id_token() -> oidc.IdentityToken:
-    if "EXTREMELY_DANGEROUS_PUBLIC_OIDC_BEACON" in os.environ:
-        import requests
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--min-id-token-validity",
+        action="store",
+        help="Minimum validity of the identity token in seconds",
+        type=lambda x: timedelta(seconds=int(x)),
+        default=timedelta(seconds=20),
+    )
 
-        resp = requests.get(
-            "https://raw.githubusercontent.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/refs/heads/current-token/oidc-token.txt"
-        )
-        resp.raise_for_status()
-        id_token = resp.text.strip()
-        return oidc.IdentityToken(id_token)
 
-    if "CI" in os.environ:
-        token = oidc.detect_credential()
-        if token is None:
-            pytest.fail("misconfigured CI: no ambient OIDC credential")
-        return oidc.IdentityToken(token)
+def _jwt_cache() -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    def _decorator(
+        fn: Callable[[pytest.Config], oidc.IdentityToken],
+    ) -> Callable[[pytest.Config], oidc.IdentityToken]:
+        @functools.wraps(fn)
+        def _wrapped(pytestconfig: pytest.Config) -> oidc.IdentityToken:
+            # Cache the token for the duration of the test run,
+            # as long as the returned token is not yet expired
+            if hasattr(_wrapped, "token"):
+                assert isinstance(_wrapped.token, oidc.IdentityToken)
+                min_validity = pytestconfig.getoption("--min-id-token-validity")
+                if _is_valid_at(_wrapped.token, datetime.now() + min_validity):
+                    return _wrapped.token
 
-    pytest.fail("no OIDC token available for tests")
+            token = fn(pytestconfig)
+            setattr(_wrapped, "token", token)
+            return token
+
+        return _wrapped
+
+    return _decorator
+
+
+def _is_valid_at(token: oidc.IdentityToken, reference_time: datetime) -> bool:
+    # split token, b64 decode (with padding), parse as json, validate expiry
+    payload = str(token).split(".")[1]
+    payload += "=" * (4 - len(payload) % 4)
+    payload_json = json.loads(b64decode(payload))
+
+    expiry = datetime.fromtimestamp(payload_json["exp"])
+    return reference_time < expiry
+
+
+@pytest.fixture
+@_jwt_cache()
+def id_token(pytestconfig: pytest.Config) -> oidc.IdentityToken:
+    # following code is modified from extremely-dangerous-public-oidc-beacon download-token.py.
+    # Caching can be made smarter (to return the cached token only if it is valid) if token
+    # starts going invalid during runs
+    MIN_VALIDITY = timedelta(seconds=20)
+    MAX_RETRY_TIME = timedelta(minutes=5 if os.getenv("CI") else 1)
+    RETRY_SLEEP_SECS = 30 if os.getenv("CI") else 5
+    GIT_URL = "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon.git"
+
+    def git_clone(url: str, dir: str) -> None:
+        base_cmd = ["git", "clone", "--quiet", "--branch", "current-token", "--depth", "1"]
+        subprocess.run(base_cmd + [url, dir], check=True)
+
+    start_time = datetime.now()
+    while datetime.now() <= start_time + MAX_RETRY_TIME:
+        with TemporaryDirectory() as tempdir:
+            git_clone(GIT_URL, tempdir)
+
+            with Path(tempdir, "oidc-token.txt").open() as f:
+                token = oidc.IdentityToken(f.read().rstrip())
+
+            if _is_valid_at(token, datetime.now() + MIN_VALIDITY):
+                return token
+
+        print(f"Current token expires too early, retrying in {RETRY_SLEEP_SECS} seconds.")
+        time.sleep(RETRY_SLEEP_SECS)
+
+    raise TimeoutError(f"Failed to find a valid token in {MAX_RETRY_TIME}")

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -23,9 +23,7 @@ from pypi_attestations._cli import (
 )
 from pypi_attestations._impl import Attestation, AttestationError, ConversionError, Distribution
 
-ONLINE_TESTS = (
-    "CI" in os.environ or "EXTREMELY_DANGEROUS_PUBLIC_OIDC_BEACON" in os.environ
-) and "TEST_OFFLINE" not in os.environ
+ONLINE_TESTS = "CI" in os.environ and "TEST_OFFLINE" not in os.environ
 
 online = pytest.mark.skipif(not ONLINE_TESTS, reason="online tests not enabled")
 

--- a/test/test_impl.py
+++ b/test/test_impl.py
@@ -22,9 +22,7 @@ from sigstore.verify import Verifier, policy
 
 import pypi_attestations._impl as impl
 
-ONLINE_TESTS = (
-    "CI" in os.environ or "EXTREMELY_DANGEROUS_PUBLIC_OIDC_BEACON" in os.environ
-) and "TEST_OFFLINE" not in os.environ
+ONLINE_TESTS = "CI" in os.environ and "TEST_OFFLINE" not in os.environ
 
 online = pytest.mark.skipif(not ONLINE_TESTS, reason="online tests not enabled")
 


### PR DESCRIPTION
Solves frequent issues in CI where the [OIDC token downloaded for testing](https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon) is no longer valid due to how GitHub caches requests. See [here](https://github.com/pypi/pypi-attestations/actions/runs/21501376718/job/61949110779?pr=165) for a recent example.


This solution is based in the [workaround](https://github.com/sigstore/sigstore-conformance/blob/1fba15acf081c5e52a1de956f2a6502eb3ff5288/test/conftest.py#L133) that `sigstore-conformance` uses, where the token is downloaded by cloning the GH repo (instead of trying to directly access the file at `raw.githubusercontent.com`)