### PR TITLE
Disable mypy's reachability checks for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,8 @@ strict_equality = true
 warn_no_return = true
 warn_redundant_casts = true
 warn_return_any = true
-warn_unreachable = true
+# https://github.com/python/mypy/issues/21132
+# warn_unreachable = true
 warn_unused_configs = true
 warn_unused_ignores = true
 


### PR DESCRIPTION
See https://github.com/python/mypy/issues/21132 for context -- mypy incorrectly determines that some of our (test) code is unreachable, but does so for reasons that are _probably_ imprecision in Pydantic's `TypeAdapter` typing. We don't have a clear resolution pathway on our end, so let's just disable this optional check for now.