### PR TITLE
Update help: PYPI_FILE can be a local file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ pypi-attestations verify pypi --repository https://github.com/sigstore/sigstore-
   ~/Downloads/sigstore-3.6.1-py3-none-any.whl
 ```
 
-This command downloads the artifact and its provenance from PyPI. The artifact
+This command downloads the artifact, if needed, and its provenance from PyPI. The artifact
 is then verified against the provenance, while also checking that the provenance's
 signing identity matches the repository specified by the user.
 

--- a/src/pypi_attestations/_cli.py
+++ b/src/pypi_attestations/_cli.py
@@ -150,8 +150,10 @@ def _parser() -> argparse.ArgumentParser:
         "distribution_file",
         metavar="PYPI_FILE",
         type=str,
-        help="PyPI file to verify, can be either: (1) pypi:$FILE_NAME (e.g. "
-        "pypi:sampleproject-1.0.0.tar.gz) or (2) A direct URL to files.pythonhosted.org",
+        help="PyPI file to verify, can be: "
+        "(1) a path to a local file, "
+        "(2) pypi:$FILE_NAME (e.g. pypi:sampleproject-1.0.0.tar.gz) or "
+        "(3) A direct URL to files.pythonhosted.org",
     )
 
     verify_pypi_command.add_argument(


### PR DESCRIPTION
## Summary

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist
<!-- Remove the ones that don't apply to this PR -->

### Making a release
- [ ] Bump the version in `src/pypi_attestations/__init__.py`
- [ ] Add a new subheading in the CHANGELOG for the new version
- [ ] Add a link at the bottom of the CHANGELOG for the diff of the new version

### Adding new public-facing APIs
- [ ] Expose the new types/functions in `src/pypi_attestations/__init__.py`

The [README](https://github.com/pypi/pypi-attestations#verifying-a-pypi-package) says:

> The package to verify can be passed either as a path to a local file, a pypi: prefixed filename (e.g: 'pypi:sampleproject-1.0.0-py3-none-any.whl'), or as a direct URL to the artifact hosted by PyPI.

Update `pypi-attestations verify pypi --help` to also mention local file.

Plus update README, no need to download for local file.
