### PR TITLE
Update min sigstore version to 4.5.0 and prep `0.0.30` release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for CircleCI attestations ([#166](https://github.com/pypi/pypi-attestations/pull/166/)).
   This is work aligned with adding CircleCI as a Trusted Publisher in pypi. ([#19349](https://github.com/pypi/warehouse/pull/19349))
 
+### Changed
+
+- Updated the minimum supported `sigstore` dependency to `4.5`.
+
 ## [0.0.29]
 
 ### Added
@@ -344,7 +348,8 @@ This is a corrective release for [0.0.14].
 
 - Initial implementation
 
-[Unreleased]: https://github.com/pypi/pypi-attestations/compare/v0.0.29...HEAD
+[Unreleased]: https://github.com/pypi/pypi-attestations/compare/v0.0.30...HEAD
+[0.0.30]: https://github.com/pypi/pypi-attestations/compare/v0.0.29...v0.0.30
 [0.0.29]: https://github.com/pypi/pypi-attestations/compare/v0.0.28...v0.0.29
 [0.0.28]: https://github.com/pypi/pypi-attestations/compare/v0.0.27...v0.0.28
 [0.0.27]: https://github.com/pypi/pypi-attestations/compare/v0.0.26...v0.0.27

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "pydantic >= 2.10.0",
     "requests",
     "rfc3986",
-    "sigstore >= 4.0, < 5.0",
+    "sigstore >= 4.5, < 5.0",
     "sigstore-models",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Update sigstore to use `4.5.0` (to fix https://github.com/pypa/gh-action-pypi-publish/issues/415) and prepare a release for `0.0.30`

<!-- What's the purpose of the change? What does it do, and why? -->

## Checklist
<!-- Remove the ones that don't apply to this PR -->

### Making a release
- [x] Bump the version in `src/pypi_attestations/__init__.py`
- [x] Add a new subheading in the CHANGELOG for the new version
- [x] Add a link at the bottom of the CHANGELOG for the diff of the new version

(the version bump was already done, the `0.0.30` version has not been released yet)

